### PR TITLE
Add option to run chrome in headless mode.

### DIFF
--- a/gauge-archetype-selenium/pom.xml
+++ b/gauge-archetype-selenium/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>gauge-archetype-selenium</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <name>Archetype - gauge-archetype-selenium</name>
     <description>Archetype for Gauge Java with Selenium</description>
     <url>http://github.com/getgauge/gauge-mvn-archetypes</url>

--- a/gauge-archetype-selenium/src/main/resources/archetype-resources/src/test/java/driver/DriverFactory.java
+++ b/gauge-archetype-selenium/src/main/resources/archetype-resources/src/test/java/driver/DriverFactory.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 public class DriverFactory {
 
@@ -18,10 +19,16 @@ public class DriverFactory {
         String browser = System.getenv("BROWSER");
         if (browser == null) {
             ChromeDriverManager.getInstance().setup();
-            return new ChromeDriver();
+
+            ChromeOptions options = new ChromeOptions();
+            if ("Y".equalsIgnoreCase(System.getenv("HEADLESS"))) {
+                options.addArguments("--headless");
+                options.addArguments("--disable-gpu");
+            }
+
+            return new ChromeDriver(options);
         }
-        switch (browser)
-        {
+        switch (browser) {
             case "IE":
                 InternetExplorerDriverManager.getInstance().setup();
                 return new InternetExplorerDriver();


### PR DESCRIPTION
Support running chrome in headless mode.

https://developers.google.com/web/updates/2017/04/headless-chrome

The flags are ignored on earlier versions of chrome.