### PR TITLE
package information is now taken into account. PLUS upgrade to JUNIT 5

### DIFF
--- a/gauge-archetype-java/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/gauge-archetype-java/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -6,7 +6,7 @@
         name="gauge-archetype-java">
 
     <fileSets>
-        <fileSet>
+        <fileSet packaged="true" filtered="true">
             <directory>src/test/java</directory>
             <includes>
                 <include>StepImplementation.java</include>

--- a/gauge-archetype-java/src/main/resources/archetype-resources/pom.xml
+++ b/gauge-archetype-java/src/main/resources/archetype-resources/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-java/src/main/resources/archetype-resources/pom.xml
+++ b/gauge-archetype-java/src/main/resources/archetype-resources/pom.xml
@@ -14,9 +14,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gauge-archetype-java/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
+++ b/gauge-archetype-java/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
@@ -1,4 +1,4 @@
-package ${package}
+package ${package};
 
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.Table;

--- a/gauge-archetype-java/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
+++ b/gauge-archetype-java/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
@@ -1,3 +1,5 @@
+package ${package}
+
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.Table;
 import com.thoughtworks.gauge.TableRow;

--- a/gauge-archetype-java/src/test/resources/projects/test1/archetype.properties
+++ b/gauge-archetype-java/src/test/resources/projects/test1/archetype.properties
@@ -1,3 +1,4 @@
 groupId=com.test
 artifactId=testArtifact
 version=1.0-SNAPSHOT
+package=com.test.pkg

--- a/gauge-archetype-java/src/test/resources/projects/test1/reference/pom.xml
+++ b/gauge-archetype-java/src/test/resources/projects/test1/reference/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-java/src/test/resources/projects/test1/reference/pom.xml
+++ b/gauge-archetype-java/src/test/resources/projects/test1/reference/pom.xml
@@ -14,9 +14,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gauge-archetype-java/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
+++ b/gauge-archetype-java/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
@@ -1,4 +1,4 @@
-package com.test.pkg
+package com.test.pkg;
 
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.Table;

--- a/gauge-archetype-java/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
+++ b/gauge-archetype-java/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
@@ -1,3 +1,5 @@
+package com.test.pkg
+
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.Table;
 import com.thoughtworks.gauge.TableRow;

--- a/gauge-archetype-selenium/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/gauge-archetype-selenium/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -6,7 +6,7 @@
         name="gauge-archetype-selenium">
 
   <fileSets>
-    <fileSet>
+    <fileSet filtered="true" packaged="true">
       <directory>src/test/java</directory>
       <includes>
         <include>*.java</include>

--- a/gauge-archetype-selenium/src/main/resources/archetype-resources/pom.xml
+++ b/gauge-archetype-selenium/src/main/resources/archetype-resources/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-selenium/src/main/resources/archetype-resources/pom.xml
+++ b/gauge-archetype-selenium/src/main/resources/archetype-resources/pom.xml
@@ -14,9 +14,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-selenium/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
+++ b/gauge-archetype-selenium/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
@@ -1,3 +1,4 @@
+package ${package}
 import com.thoughtworks.gauge.Gauge;
 import com.thoughtworks.gauge.Step;
 import driver.Driver;

--- a/gauge-archetype-selenium/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
+++ b/gauge-archetype-selenium/src/main/resources/archetype-resources/src/test/java/StepImplementation.java
@@ -1,4 +1,5 @@
-package ${package}
+package ${package};
+
 import com.thoughtworks.gauge.Gauge;
 import com.thoughtworks.gauge.Step;
 import driver.Driver;

--- a/gauge-archetype-selenium/src/test/resources/projects/test1/archetype.properties
+++ b/gauge-archetype-selenium/src/test/resources/projects/test1/archetype.properties
@@ -1,3 +1,4 @@
 groupId=com.test
 artifactId=testArtifact
 version=1.0-SNAPSHOT
+package=com.test.pkg

--- a/gauge-archetype-selenium/src/test/resources/projects/test1/reference/pom.xml
+++ b/gauge-archetype-selenium/src/test/resources/projects/test1/reference/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-selenium/src/test/resources/projects/test1/reference/pom.xml
+++ b/gauge-archetype-selenium/src/test/resources/projects/test1/reference/pom.xml
@@ -14,9 +14,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-selenium/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
+++ b/gauge-archetype-selenium/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
@@ -1,3 +1,4 @@
+package com.test.pkg
 import com.thoughtworks.gauge.Gauge;
 import com.thoughtworks.gauge.Step;
 import driver.Driver;

--- a/gauge-archetype-selenium/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
+++ b/gauge-archetype-selenium/src/test/resources/projects/test1/reference/src/test/java/com/test/pkg/StepImplementation.java
@@ -1,4 +1,5 @@
-package com.test.pkg
+package com.test.pkg;
+
 import com.thoughtworks.gauge.Gauge;
 import com.thoughtworks.gauge.Step;
 import driver.Driver;


### PR DESCRIPTION
addresses: https://github.com/getgauge/gauge-mvn-archetypes/issues/7