### PR TITLE
gauge-java version bumped to 0.6.7

### DIFF
--- a/gauge-archetype-java/src/main/resources/archetype-resources/pom.xml
+++ b/gauge-archetype-java/src/main/resources/archetype-resources/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-java/src/test/resources/projects/test1/reference/pom.xml
+++ b/gauge-archetype-java/src/test/resources/projects/test1/reference/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-selenium/src/main/resources/archetype-resources/pom.xml
+++ b/gauge-archetype-selenium/src/main/resources/archetype-resources/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gauge-archetype-selenium/src/test/resources/projects/test1/reference/pom.xml
+++ b/gauge-archetype-selenium/src/test/resources/projects/test1/reference/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.6.5</version>
+            <version>0.6.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
For https://github.com/getgauge/gauge-mvn-archetypes/issues/9

bumped `gauge-java` version to 0.6.7